### PR TITLE
Server being reloaded

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,4 +3,4 @@
 from flaskapp import app
 
 if __name__ == '__main__':
-    app.run(debug=True, host='127.0.0.1')
+    app.run(host='127.0.0.1', port=80, use_reloader=False, debug=False)


### PR DESCRIPTION
Avoiding server reload when debug mode is on, setting default port to 80 and setting server debug to false.

The reload was happening due to a configuration when the server was being launched on debug mode. 

Found the solution by adding [use_reloader](https://stackoverflow.com/questions/9449101/how-to-stop-flask-from-initialising-twice-in-debug-mode). Also set variable debug to false

